### PR TITLE
Using Kalendae from a dialog that is shown from a scrolled page

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -75,7 +75,22 @@ var util = Kalendae.util = {
 		if (!(elem = util.$(elem))) return;
 		elem.className = util.trimString(elem.className.replace(new RegExp("(^|\\s+)" + className + "(\\s+|$)"), ' '));
 	},
-
+		
+	filterResults: function(n_win, n_docel, n_body) {
+  	var n_result = n_win ? n_win : 0;
+  	if (n_docel && (!n_result || (n_result > n_docel)))
+  		n_result = n_docel;
+  	return n_body && (!n_result || (n_result > n_body)) ? n_body : n_result;
+  },
+	
+	scrollTop: function() {
+  	return util.filterResults (
+  		window.pageYOffset ? window.pageYOffset : 0,
+  		document.documentElement ? document.documentElement.scrollTop : 0,
+  		document.body ? document.body.scrollTop : 0
+  	);
+  },	
+	
 	getPosition: function (elem, isInner) {
 		var x = elem.offsetLeft,
 			y = elem.offsetTop,
@@ -87,7 +102,7 @@ var util = Kalendae.util = {
 				y += elem.offsetTop;
 			}
 		}
-		
+		y += util.scrollTop();
 		r[0] = r.left = x;
 		r[1] = r.top = y;
 		return r;


### PR DESCRIPTION
I am using Bootstrap and using the Modal dialog widget. Inside my widget I have a Kalendae object. 

If I display a modal dialog box and the page is scrolled down than Kalendae does not properly calculate the `top` position because it doesnt factor in the amount the page is scrolled down.

This pull request tweaks the `getPosition` method and adds the scroll top to the final coordinates.
