### PR TITLE
Fixed unicode nav buttons

### DIFF
--- a/build/kalendae.css
+++ b/build/kalendae.css
@@ -64,21 +64,18 @@
 .kalendae .k-btn-previous-month,
 .kalendae .k-btn-next-month,
 .kalendae .k-btn-previous-year,
-.kalendae .k-btn-next-year {width:16px;height:16px;cursor:pointer;position:absolute;top:0;color:#777;font-size:20px;line-height:14px;}
+.kalendae .k-btn-next-year {width:16px;height:16px;cursor:pointer;position:absolute;top:-3px;color:#777;font-size:26px; line-height: 18px; font-weight: bold; font-family: arial}
 
 .kalendae .k-btn-previous-year {left:0;}
 .kalendae .k-btn-previous-month {left:16px;}
 .kalendae .k-btn-next-month {right:16px;}
 .kalendae .k-btn-next-year {right:0;}
 
-.kalendae .k-btn-previous-month:after {content:"\276E";}
-.kalendae .k-btn-next-month:after {content:"\276F";}
+.kalendae .k-btn-previous-month:after {content:"\2039";}
+.kalendae .k-btn-next-month:after {content:"\203A";}
 
-.kalendae .k-btn-previous-year:after {content:"\276E\276E";}
-.kalendae .k-btn-next-year:after {content:"\276F\276F";}
-
-.kalendae .k-btn-previous-year,
-.kalendae .k-btn-next-year {letter-spacing:-4px;text-align:left;}
+.kalendae .k-btn-previous-year:after {content:"\00AB";}
+.kalendae .k-btn-next-year:after {content:"\00BB";}
 
 .kalendae .k-btn-previous-month:hover,
 .kalendae .k-btn-next-month:hover {color:#7EA0E2;}


### PR DESCRIPTION
Dear all,

We are using Kalende for a web app and we noticed that the month/year buttons have issues with a lot of browsers on non-mac OSs.

(iPhone 4s should be affected too. I can't confirm at 100%.)

The bug happens 'cause the symbols chosen to represent the "arrows", \276E and \276F, are not available everywhere and the letter-spacing css3 property used to bring double arrows together hasn't the same behaviour on each browser.

This pull request changes \276E in \2039 and \276F in \203A for month navigation, uses the "double" version of those characters without forcing letter-spacing property for year navigation, changes font-family to arial and makes some little adjustments.

Here you can see the differences:

Windows before:
http://img407.imageshack.us/img407/82/kalendaewindowsbefore.png

Windows after:
http://img217.imageshack.us/img217/6995/kalendaewindowsafter.png

Chrome @ Ubuntu 11.10 before and after
http://img88.imageshack.us/img88/9976/chromeubuntu1110.png

...and how about Mac? 

Well, the new "arrows" are uglier and smaller than the older ones, but imho they are acceptable:
Safari: http://img59.imageshack.us/img59/2866/107safariscreenshot2012.png
Chrome:http://img714.imageshack.us/img714/9056/107chromescreenshot2012.png

(Don't try Helvetica 'cause \2039 and  \203A are rendered almost like < and >)

Hope it helps

GT

PS: sorry about the poor quality screenshots, it's just to give an idea
