### PR TITLE
Add a clean target and attempt to build with uglifyjs if it exists locally before going out to the public Internet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ ifneq ($(UGLIFYJS), "")
 else
 	curl -s \
 		--data-urlencode 'js_code@build/kalendae.js' \
-	 	--data-urlencode 'output_format=text' \
+		--data-urlencode 'output_format=text' \
 		--data-urlencode 'output_info=errors' \
 		http://closure-compiler.appspot.com/compile
 endif


### PR DESCRIPTION
I'm okay if you decide not to accept this pull request, but there's something about depending on the public Internet to build JS that I do not like, especially since I already have a local build environment.  Also, once the JS files were built they could not be re-built (with make) until the files were actually removed from build/, so I added a clean target to do that.
