### PR TITLE
Fixed a couple edge cases for directionScrolling that were related to 'today-future', 'future', 'today-past', 'past'.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -445,7 +445,7 @@ Kalendae.prototype = {
 			var diff = -(moment().diff(month, 'months'));		
 			if (opts.direction==='today-past' || opts.direction==='past') {
 
-				if (diff <= 0) {
+				if (diff < 0) {
 					this.disableNextMonth = false;
 					util.removeClassName(this.container, classes.disableNextMonth);
 				} else {
@@ -455,7 +455,7 @@ Kalendae.prototype = {
 
 			} else if (opts.direction==='today-future' || opts.direction==='future') {
 
-				if (diff > opts.months) {
+				if (diff >= opts.months) {
 					this.disablePreviousMonth = false;
 					util.removeClassName(this.container, classes.disablePreviousMonth);
 				} else {


### PR DESCRIPTION
If you were using 'today-future' or 'future', and you navigate to the next month, the previous month arrow wasn't available to return to the current month (meaning current month in time, not current month in navigation). 

Similarly, for 'past', or 'today-past', the next month arrow wasn't available to return to the current month if you navigated to the previous month.
