### PR TITLE
Input calendar inside overflow:auto/scroll containers.

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -59,6 +59,16 @@ Kalendae.Input = function (targetElement, options) {
 	util.addEvent($input, 'keyup', function (event) {
 		self.setSelected(this.value);
 	});
+
+	var $scrollContainer = util.scrollContainer($input);
+
+	if( $scrollContainer ) {
+
+		// Hide calendar when $scrollContainer is scrolled
+		util.addEvent($scrollContainer, 'scroll', function (event) {
+			$input.blur();
+		});
+	}
 	
 	self.subscribe('change', function () {
 		$input.value = self.getSelected();
@@ -83,27 +93,29 @@ Kalendae.Input.prototype = util.merge(Kalendae.prototype, {
 		var $container = this.container,
 			style = $container.style,
 			$input = this.input,
-			pos = util.getPosition($input);
-		
+			pos = util.getPosition($input),
+			$scrollContainer = util.scrollContainer($input),
+			scrollTop = $scrollContainer ? $scrollContainer.scrollTop : 0;
+
 		style.display = '';
 		switch (opts.side) {
 			case 'left':
 				style.left = (pos.left - util.getWidth($container) + this.settings.offsetLeft) + 'px';
-				style.top  = (pos.top + this.settings.offsetTop) + 'px';
+				style.top  = (pos.top + this.settings.offsetTop - scrollTop) + 'px';
 				break;
 			case 'right':
 				style.left = (pos.left + util.getWidth($input)) + 'px';
-				style.top  = (pos.top + this.settings.offsetTop) + 'px';
+				style.top  = (pos.top + this.settings.offsetTop - scrollTop) + 'px';
 				break;
 			case 'top':
 				style.left = (pos.left + this.settings.offsetLeft) + 'px';
-				style.top  = (pos.top - util.getHeight($container) + this.settings.offsetTop) + 'px';
+				style.top  = (pos.top - util.getHeight($container) + this.settings.offsetTop - scrollTop) + 'px';
 				break;
 			case 'bottom':
 				/* falls through */
 			default:
 				style.left = (pos.left + this.settings.offsetLeft) + 'px';
-				style.top  = (pos.top + util.getHeight($input) + this.settings.offsetTop) + 'px';
+				style.top  = (pos.top + util.getHeight($input) + this.settings.offsetTop - scrollTop) + 'px';
 				break;
 		}
 		

--- a/src/util.js
+++ b/src/util.js
@@ -97,6 +97,14 @@ var util = Kalendae.util = {
 		} while ((elem = elem.offsetParent));
 		return false;
 	},
+
+	scrollContainer: function (elem) {
+		do {
+			var overflow = util.getStyle(elem, 'overflow');
+			if (overflow === 'auto' || overflow === 'scroll') return elem;
+		} while ((elem = elem.parentNode) && elem != window.document.body);
+		return null;
+	},
 	
 	getPosition: function (elem, isInner) {
 		var x = elem.offsetLeft,


### PR DESCRIPTION
I have some inputs inside a `<div/>` with `overflow:auto;` and, when I scroll this div, the position is incorrect. I've made this little change to consider `parent_element_with_scroll.scrollTop` when setting the position.
