### PR TITLE
Forgotten false positive check for IE8

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -1,6 +1,5 @@
-
 Kalendae.Input = function (targetElement, options) {
-	if (typeof document.addEventListener !== 'function') return;
+	if (typeof document.addEventListener !== 'function'  && !util.isIE8()) return;
 
 	var $input = this.input = util.$(targetElement),
 		overwriteInput;


### PR DESCRIPTION
The false positive check for IE8 is made on the main Kalendae class, but not on the Kalendae.Input class.

Without this fix, you can't use new Kalendae.Input with IE8.
