### PR TITLE
When `self._sel` is an empty array, `self.blackout()` always returns false

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -81,7 +81,7 @@ var Kalendae = function (targetElement, options) {
 		var bdates = parseDates(opts.blackout, opts.parseSplitDelimiter);
 		self.blackout = function (input) {
 			input = moment(input).yearDay();
-			if (input < 1 || !self._sel || self._sel.length < 1) return false;
+			if (input < 1 || !self._sel) return false;
 			var i = bdates.length;
 			while (i--) if (bdates[i].yearDay() === input) return true;
 			return false;			


### PR DESCRIPTION
Fixed ChiperSoft/Kalendae#69

This PR is correct.
