### PR TITLE
Why the function 'isArray' for an empty array returns false?​

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -168,14 +168,7 @@ var util = Kalendae.util = {
 	},
 	
 	isArray: function (array) {
-		return !(
-			!array || 
-			(!array.length || array.length === 0) || 
-			typeof array !== 'object' || 
-			!array.constructor || 
-			array.nodeType || 
-			array.item 
-		);
+		return Object.prototype.toString.call(array) == "[object Array]"
 	}
 };
 


### PR DESCRIPTION
This pull request is re-implement `util.isArray` method. Actually I've stolen isArray from underscore.js library

You can test the old and new implementation of `isArray`: 

http://jsfiddle.net/aratak/JY2JK/

As you can see `isArray` with an empty string returns `false`
