### PR TITLE
Fix IE9 input blur bug

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -49,11 +49,8 @@ Kalendae.Input = function (targetElement, options) {
 	});
 	
 	util.addEvent($input, 'blur', function () {
-		if (noclose) {
-			noclose = false;
-			$input.focus();
-		}
-		else self.hide();
+		noclose = false;
+		self.hide();
 	});
 	util.addEvent($input, 'keyup', function (event) {
 		self.setSelected(this.value);


### PR DESCRIPTION
This fixes a bug in IE9 where kalendae doesn't close on date pick or close button click
