### PR TITLE
Set default box-sizing for .k-header and .k-days

### DIFF
--- a/build/kalendae.css
+++ b/build/kalendae.css
@@ -136,6 +136,9 @@
 .kalendae .k-days span {
 	float:left;
 	margin:1px 1px;
+    	box-sizing:content-box;
+    	-moz-box-sizing:content-box;
+    	-webkit-box-sizing:content-box;
 }
 
 .kalendae .k-header span {


### PR DESCRIPTION
Added default box-sizing styles to the spans within .kalendae .k-header and .k-days. This should alleviate issues with frameworks like Zurb Foundation, which set box-sizing to 'border-box' for the entire page.