### PR TITLE
Only include valid dates

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -582,10 +582,14 @@ var parseDates = function (input, delimiter, format) {
 	}
 
 	var c = input.length,
-		i = 0;
+		i = 0,
+		m;
 
 	do {
-		if (input[i]) output.push( moment(input[i], format).hours(12) );
+		if (input[i]) {
+			m = moment(input[i], format).hours(12);
+			if (m.isValid()) output.push(m);
+		}
 	} while (++i < c);
 
 	return output;


### PR DESCRIPTION
This fixes an issue where the calendar will jump to the date 0000-00-00 when you start typing.

The problem is particularly nasty when past dates aren't allowed, since you'll then have to guess at the correct date format to move the calendar back to a valid date (or, given enough patience, you could increment the month through the years :-))
