### PR TITLE
Replace uses of $ with jQuery

### DIFF
--- a/src/jq.js
+++ b/src/jq.js
@@ -1,13 +1,12 @@
-
 if (typeof jQuery !== 'undefined' && (typeof document.addEventListener === 'function' || util.isIE8())) {
 	jQuery.fn.kalendae = function (options) {
 		this.each(function (i, e) {
 			if (e.tagName === 'INPUT') {
 				//if element is an input, bind a popup calendar to the input.
-				$(e).data('kalendae', new Kalendae.Input(e, options));
+				jQuery(e).data('kalendae', new Kalendae.Input(e, options));
 			} else {
 				//otherwise, insert a flat calendar into the element.
-				$(e).data('kalendae', new Kalendae($.extend({}, {attachTo:e}, options)));
+				jQuery(e).data('kalendae', new Kalendae(jQuery.extend({}, {attachTo:e}, options)));
 			}
 		});
 		return this;


### PR DESCRIPTION
The jQuery integration did not work for me because I'm in noConflict mode and there were some uses of the $ shorthand in Kalendae.
