### PR TITLE
Incorrect viewStartDate

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -396,7 +396,7 @@ Kalendae.prototype = {
 
 		if (draw !== false) {
 			if (new_dates[0]) {
-				this.viewStartDate = moment(new_dates[0], this.settings.format);
+				this.viewStartDate = moment(new_dates[0], this.settings.format).date(1);
 			}
 			this.draw();
 		}


### PR DESCRIPTION
This fixes a bug, which prevents you to switch to the current month, when the date is set to a day of the previous month. Steps to reproduce the issue:
- create a kalendae attached to an input with the option: { direction: 'today-past' }
- go back to the previous month, and choose a day which is greater than the current day of month (e.g. select 28 February, when the current day is 4 March)
- close kalendae
- open it again, and the next month button is not available