### PR TITLE
Fixes #134

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -470,7 +470,7 @@ Kalendae.prototype = {
 
 	draw : function draw() {
 		// return;
-		var month = moment(this.viewStartDate).startOf('day').hours(12), //force middle of the day to avoid any weird date shifts
+		var month = moment(this.viewStartDate).startOf('day').add(12, 'hours'), //force middle of the day to avoid any weird date shifts
 			day,
 			classes = this.classes,
 			cal,
@@ -516,7 +516,7 @@ Kalendae.prototype = {
 
 				if (!(this.blackout(day) || this.direction(day) || (day.month() != month.month() && opts.dayOutOfMonthClickable === false)) || s>0) klass.push(classes.dayActive);
 
-				if (day.startOf('day').yearDay() === today.yearDay()) klass.push(classes.dayToday);
+				if (day.clone().startOf('day').yearDay() === today.yearDay()) klass.push(classes.dayToday);
 
 				dateString = day.format(this.settings.dayAttributeFormat);
 				if (opts.dateClassMap[dateString]) klass.push(opts.dateClassMap[dateString]);


### PR DESCRIPTION
Fixes #134 !

There were two issues here, first is that in Safari on October 2017, when you call `startOf('day')`, it actually sends you back to September 30th at 8pm (or at least in my timezone - +9:30 GMT). Because of that, when you call `hours(12)`, you are setting the time to 12am on the 30th of September so the calendar actually repeats September. With the use of `startOf('day')`, we can safely add 12 hours to whatever the date is and it will either be the middle of the day (like good browsers) or will get at least far enough away from causing issues with daylight savings etc (the reason you had the 12 hours there to begin with).

The second issue is that all the hard work for the 12 hours is actually undone with how you do the "today" check. The "day" is mutated back to the start but you only really need to go to the start of the day for that specific if-statement so I cloned the day object specifically for that.