### PR TITLE
Enable bubbling of DOM change event

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -86,7 +86,7 @@ var util = Kalendae.util = {
 	fireEvent: function (elem, event) {
 		if (document.createEvent) {
 			var e = document.createEvent('HTMLEvents');
-			e.initEvent(event, false, true);
+			e.initEvent(event, true, true);
 			elem.dispatchEvent(e);
 		} else if (document.createEventObject) {
 			elem.fireEvent('on' + event) ;


### PR DESCRIPTION
This way the event can be captured by parent elements. This can be useful when you use the change event to see if something in the form changed.