### PR TITLE
Several additions: endDate view option, 'draw-end' event, removeAllSelected() method, caption changes, & 'k-blackout' class 

### DIFF
--- a/build/kalendae.css
+++ b/build/kalendae.css
@@ -69,6 +69,9 @@
 /** Month Title Row **/
 .kalendae .k-title {text-align:center;white-space:nowrap;position:relative;height:18px;}
 .kalendae .k-caption {font-size:12px;line-height:18px;}
+.kalendae .k-caption-month,
+.kalendae .k-caption-year {display: inline;}
+.kalendae .k-caption-month {margin-right: 0.4em;}
 
 
 /** Month and Year Buttons **/

--- a/build/kalendae.js
+++ b/build/kalendae.js
@@ -40,7 +40,7 @@ var Kalendae = function (targetElement, options) {
 		$container = self.container = util.make('div', {'class':classes.container}),
 		calendars = self.calendars = [],
 		startDay = moment().day(opts.weekStart),
-		vsd,
+		vsd, ved,
 		columnHeaders = [],
 		$cal,
 		$title,
@@ -68,20 +68,26 @@ var Kalendae = function (targetElement, options) {
 		}
 	}
 
-    //set the view month
-    if (!!opts.viewStartDate) {
-        vsd = moment(opts.viewStartDate, opts.format);
-    } else {
-        vsd = moment();
-    }
-    self.viewStartDate = vsd.date(1);
+	//set the view month
+	if (!!opts.viewStartDate) {
+		vsd = moment(opts.viewStartDate, opts.format);
+	} else {
+		vsd = moment();
+	}
+	self.viewStartDate = vsd.date(1);
 
-    //process default selected dates
-    self._sel = [];
-    if (!!opts.selected) {
-        self.setSelected(opts.selected, false);
-        self.viewStartDate = moment(self._sel[0]);
-    }
+	//set the end range
+	if (!!opts.endDate) {
+		ved = moment(opts.endDate, opts.format);
+		self.endDate = ved;
+	}
+
+	//process default selected dates
+	self._sel = [];
+	if (!!opts.selected) {
+		self.setSelected(opts.selected, false);
+		self.viewStartDate = moment(self._sel[0]);
+	}
 
 	var viewDelta = ({
 		'past'          : opts.months-1,
@@ -139,7 +145,9 @@ var Kalendae = function (targetElement, options) {
 		util.make('a', {'class':classes.previousMonth}, $title);          //previous button
 		util.make('a', {'class':classes.nextYear}, $title);               //next button
 		util.make('a', {'class':classes.nextMonth}, $title);              //next button
-		$caption = util.make('span', {'class':classes.caption}, $title);  //title caption
+		$caption = util.make('div', {'class':classes.caption}, $title);  //title caption
+        	util.make('div', {'class':classes.captionMonth}, $caption);          //month text
+        	util.make('div', {'class':classes.captionYear}, $caption);           //year text
 
 		//column headers
 		$header = util.make('div', {'class':classes.header + ' ' + (opts.dayHeaderClickable == true ? classes.dayActive : '')}, $cal);
@@ -202,7 +210,7 @@ var Kalendae = function (targetElement, options) {
 		var clickedDate;
 		if (util.hasClassName(target, classes.nextMonth)) {
 		//NEXT MONTH BUTTON
-			if (!self.disableNext && self.publish('view-changed', self, ['next-month']) !== false) {
+			if (!self.disableNextMonth && self.publish('view-changed', self, ['next-month']) !== false) {
 				self.viewStartDate.add(1, 'months');
 				self.draw();
 			}
@@ -218,7 +226,7 @@ var Kalendae = function (targetElement, options) {
 
 		} else if (util.hasClassName(target, classes.nextYear)) {
 		//NEXT MONTH BUTTON
-			if (!self.disableNext && self.publish('view-changed', self, ['next-year']) !== false) {
+			if (!self.disableNextYear && self.publish('view-changed', self, ['next-year']) !== false) {
 				self.viewStartDate.add(1, 'years');
 				self.draw();
 			}
@@ -300,6 +308,7 @@ Kalendae.prototype = {
 		direction             :'any',           /* past, today-past, any, today-future, future */
 		directionScrolling    :true,            /* if a direction other than any is defined, prevent scrolling out of range */
 		viewStartDate         :null,            /* date in the month to display.  When multiple months, this is the left most */
+		endDate               :null,            /* date calendar cannot scroll or select past */
 		blackout              :null,            /* array of dates, or function to be passed a date */
 		selected              :null,            /* dates already selected.  can be string, date, or array of strings or dates. */
 		mode                  :'single',        /* single, multiple, range */
@@ -309,7 +318,8 @@ Kalendae.prototype = {
 		subscribe             :null,            /* object containing events to subscribe to */
 
 		columnHeaderFormat    :'dd',            /* number of characters to show in the column headers */
-		titleFormat           :'MMMM, YYYY',    /* format mask for month titles. See momentjs.com for rules */
+		titleMonthFormat      :'MMMM,',         /* format mask for month titles. */
+        	titleYearFormat       :'YYYY',          /* format mask for year titles. */
 		dayNumberFormat       :'D',             /* format mask for individual days */
 		dayAttributeFormat    :'YYYY-MM-DD',    /* format mask for the data-date attribute set on every span */
 		parseSplitDelimiter   : /,\s*|\s+-\s+/, /* regex to use for splitting multiple dates from a passed string */
@@ -331,6 +341,8 @@ Kalendae.prototype = {
 		previousYear    :'k-btn-previous-year',
 		nextYear        :'k-btn-next-year',
 		caption         :'k-caption',
+        	captionMonth    :'k-caption-month',
+        	captionYear     :'k-caption-year',
 		header          :'k-header',
 		days            :'k-days',
 		week            :'k-week',
@@ -341,6 +353,7 @@ Kalendae.prototype = {
 		dayInRange      :'k-range',
 		dayInRangeStart :'k-range-start',
 		dayInRangeEnd   :'k-range-end',
+        dayBlackout     :'k-blackout',
 		dayToday        :'k-today',
 		monthSeparator  :'k-separator',
 		disablePreviousMonth    :'k-disable-previous-month-btn',
@@ -468,6 +481,8 @@ Kalendae.prototype = {
 	addSelected : function (date, draw) {
 		date = moment(date, this.settings.format).hours(12);
 
+		if (!!this.endDate && date.isAfter(this.endDate, 'day')) return false; // safety for when it wasnt a click
+
 		if(this.settings.dayOutOfMonthClickable && this.settings.mode !== 'range'){ this.makeSelectedDateVisible(date); }
 
 		switch (this.settings.mode) {
@@ -546,6 +561,18 @@ Kalendae.prototype = {
 		return false;
 	},
 
+	removeAllSelected : function (draw) {
+		var i = this._sel.length;
+		while (i--) {
+			this.removeSelected(this._sel[i], false);
+			if (i === 0) {
+				if (draw !== false) this.draw();
+				return true;
+			}
+		}
+		return false;
+	},
+
 	draw : function draw() {
 		// return;
 		var month = moment(this.viewStartDate).startOf('month').add(12, 'hours'), //force middle of the day to avoid any weird date shifts
@@ -572,10 +599,11 @@ Kalendae.prototype = {
 			//if the first day of the month is less than our week start, back up a week
 
 			cal = this.calendars[i];
-
 			cal.header.parentNode.setAttribute('data-datestart', month.format(this.settings.dayAttributeFormat));
 
-			cal.caption.innerHTML = month.format(this.settings.titleFormat);
+            cal.caption.querySelector('.k-caption-month').innerHTML = month.format(this.settings.titleMonthFormat);
+            cal.caption.querySelector('.k-caption-year').innerHTML = month.format(this.settings.titleYearFormat);
+
 			j = 0;
 			w = 0;
 			t = 0;
@@ -617,15 +645,22 @@ Kalendae.prototype = {
 					}
 				}
 
-				if (day.month() != month.month()) klass.push(classes.dayOutOfMonth);
+				if (day.month() != month.month())
+        			klass.push(classes.dayOutOfMonth);
 				else klass.push(classes.dayInMonth);
 
-				if (!(this.blackout(day) || this.direction(day) || (day.month() != month.month() && opts.dayOutOfMonthClickable === false)) || s>0) klass.push(classes.dayActive);
+				if (!(this.blackout(day) || this.direction(day) || (!!this.endDate && day.isAfter(this.endDate, 'day')) || (day.month() != month.month() && opts.dayOutOfMonthClickable === false)) || s>0 )
+					klass.push(classes.dayActive);
 
-				if (day.clone().startOf('day').yearDay() === getTodayYearDate()) klass.push(classes.dayToday);
+                if (this.blackout(day))
+                	klass.push(classes.dayBlackout);
+
+				if (day.clone().startOf('day').yearDay() === getTodayYearDate())
+        			klass.push(classes.dayToday);
 
 				dateString = day.format(this.settings.dayAttributeFormat);
-				if (opts.dateClassMap[dateString]) klass.push(opts.dateClassMap[dateString]);
+				if (opts.dateClassMap[dateString])
+        			klass.push(opts.dateClassMap[dateString]);
 
 				$span.innerHTML = day.format(opts.dayNumberFormat);
 				$span.className = klass.join(' ');
@@ -634,6 +669,7 @@ Kalendae.prototype = {
 
 				day.add(1, 'days');
 			} while (++j < 42);
+
 			z = 0;
 			if (headers.length > 0) {
 				do {
@@ -645,13 +681,25 @@ Kalendae.prototype = {
 						do {
 							if (firstDay >= startMonth && !this.direction(firstDay)) t++;
 							firstDay.add(7, 'd');
-						} while(firstDay <= endMonth)
+						} while(firstDay <= endMonth);
 
 						if (t == headers[z]) util.addClassName(cal.header.children[z], classes.daySelected);
 						else util.removeClassName(cal.header.children[z], classes.daySelected);
 					}
-				} while(++z < headers.length)
-			}
+				} while(++z < headers.length);
+
+    			if (!!opts.endDate && month.isSame(this.endDate, 'month')) {
+    				this.disableNextMonth = true;
+    				this.disableNextYear = true;
+    				util.addClassName(this.container, classes.disableNextMonth);
+    				util.addClassName(this.container, classes.disableNextYear);
+    			} else {
+    				this.disableNextMonth = false;
+    				this.disableNextYear = false;
+    				util.removeClassName(this.container, classes.disableNextMonth);
+    				util.removeClassName(this.container, classes.disableNextYear);
+    			}
+            }
 
 			month.add(1, 'months');
 		} while (++i < c);
@@ -696,6 +744,7 @@ Kalendae.prototype = {
 				}
 			}
 		}
+        this.publish('draw-end', this);
 	}
 };
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,29 @@
 
 ## In Development
 
+* 	#### From Pull Request: [#161](https://github.com/ChiperSoft/Kalendae/pull/161)
+
+	* **Element Structure**:
+		* The title is split into 2 divs for month and year so that they can be styled separately if needed. (Only breaking if your css selected `span.k-caption` instead of just `.k-caption`).
+
+	* **New Options**
+		* `endDate` - defines the last day and month which will be selectable. Prevents navigating past in months/years.
+		* `titleFormat` is replaced by the two below  to accomodate the new title div structure:
+			* `titleMonthFormat`
+			* `titleYearFormat`
+
+	* **New Methods**
+		* `removeAllSelected()` - Added to clear all selected values at once if mode is anything other than `'single'`.
+
+	* **New Events**
+		* `draw-end`- Added to enable view changes that depend on new data. Such as jQuery or other DOM maniuplations.
+
+    * **Examples**
+        * Added examples for: `endDate`,
+
+    * **Misc.**
+        * Experimental: Specifying options for `disableNextMonth` & `disableNextYear` may actually work
+
 ## 0.6.1
 
 * \#84 Added `k-range-start` and `k-range-end` css classes to the first and last selected days in a range calender.

--- a/index.html
+++ b/index.html
@@ -167,6 +167,16 @@
 
 	</script>
 
+    <hr>
+    <p>End Date - Direction: future - Single Select</p>
+    <script type="text/javascript">
+        new Kalendae(document.body, {
+            months: 3,
+            direction: 'future',
+            endDate: Kalendae.moment().startOf('month').add(75, 'days')
+        });
+    </script>
+
 
 
 	<hr>

--- a/readme.md
+++ b/readme.md
@@ -15,13 +15,13 @@ Kalendae is an attempt to do something that nobody has yet been able to do: make
 
 ##Screenshots
 
-Default calendar, no options defined.  
+Default calendar, no options defined.
 ![screenshot](http://i.imgur.com/Ig52z.png)
 
-Two month calendar attached to an input element.  
+Two month calendar attached to an input element.
 ![screenshot](http://i.imgur.com/GIR3g.png)
 
-Two month, range selection, future dates only, with weekends blacked out:  
+Two month, range selection, future dates only, with weekends blacked out:
 ![screenshot](http://i.imgur.com/JzBc7.png)
 
 ###[View The Demo Page](http://chipersoft.github.com/Kalendae/)
@@ -72,12 +72,12 @@ To ease date handling processes, Kalendae bundles the [moment.js](http://www.mom
 
 The following options are available for configuration.
 
-- `attachTo`:	The element that the calendar div will be appended to.  
+- `attachTo`:	The element that the calendar div will be appended to.
     - In `Kalendae` this defaults to the first argument on the constructor.
     - In `Kalendae.Input` this defaults to the document body.
     - Can be an Element or an element's string ID.
 
-- `format`: The format mask used when parsing date strings.  
+- `format`: The format mask used when parsing date strings.
     - Uses moment.js notation (see http://momentjs.com/docs/#/display/format )
     - If left undefined, will attempt to parse the date automatically.
     - Default is `null`.
@@ -142,14 +142,14 @@ The following settings alter the internal behavior of Kalendae and should only b
     - Default is `dd`
 
 - `titleMonthFormat`: Format string used for the month in the calendar title.
-    - Default is `"MMMM"`
+    - Default is `"MMMM,"`
 - `titleYearFormat`: Format string used for the year in the calendar title.
     - Default is `"YYYY"`
 
 - `dayNumberFormat`: Format string for individual day numbers.
 	- Default is `"D"`
 
-- `dayAttributeFormat`: Format string for the `data-date` attribute set on every span 
+- `dayAttributeFormat`: Format string for the `data-date` attribute set on every span
     - Default is `"YYYY-MM-DD"`
 
 - `parseSplitDelimiter`: RegExp used when splitting multiple dates from a passed string

--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,10 @@ The following options are available for configuration.
     - Uses the `format` definition.
     - Default is `null` (this month or month of first selected day).
 
+- `endDate`: Date defining the last day and month which will be selectable.
+    - Uses the `format` definition.
+    - Default is `null` (this month or month of first selected day).
+
 - `dateClassMap`: A key/value collection of css classes organized by date.  String date keys found in this collection will have their value attached to the SPAN tag for the date.  This allows for custom coloring for specific days.  See the first example in index.html for usage.
     - Note that this property uses the `dayAttributeFormat` option, NOT the format option, for date strings.
     - Default is `null`.
@@ -136,8 +140,11 @@ The following settings alter the internal behavior of Kalendae and should only b
 
 - `columnHeaderFormat`:	The format of moment data of the week day name to display in column headers.
     - Default is `dd`
-- `titleFormat`: Format string used in the calendar title.
-    - Default is `"MMMM, YYYY"`
+
+- `titleMonthFormat`: Format string used for the month in the calendar title.
+    - Default is `"MMMM"`
+- `titleYearFormat`: Format string used for the year in the calendar title.
+    - Default is `"YYYY"`
 
 - `dayNumberFormat`: Format string for individual day numbers.
 	- Default is `"D"`
@@ -178,7 +185,9 @@ The following functions are available on the instantiated `Kalendae` and `Kalend
 
 - `addSelected(string|Date|moment)`: Adds the passed value to the selection. Behavior varies according to the `mode` option, but matches behavior of clicking on a day in the calendar.
 
-- `removeSelected(string|Date|moment)`: removes the passed value from the selection.
+- `removeSelected(string|Date|moment)`: Removes the passed value from the selection.
+
+- `removeAllSelected()`: Clears all selected values.
 
 - `draw()`: Forces a redraw of the calendar contents.
 
@@ -218,6 +227,8 @@ Kalendae offers the following events:
 - `date-clicked` - Fires when a date has been clicked, but before the selection is changed.  Receives the date clicked as a moment object in the first parameter.  Returning false will prevent selection change.
 
 - `view-changed` - Fires when the user has clicked the next or previous month button, but before the calendar is redrawn.  Returning false will prevent the change.
+
+- `draw-end` - Fires when the draw function has finished.
 
 Additionally, Kalendae.Input provides the following events:
 

--- a/readme.md
+++ b/readme.md
@@ -15,13 +15,13 @@ Kalendae is an attempt to do something that nobody has yet been able to do: make
 
 ##Screenshots
 
-Default calendar, no options defined.
+Default calendar, no options defined.  
 ![screenshot](http://i.imgur.com/Ig52z.png)
 
-Two month calendar attached to an input element.
+Two month calendar attached to an input element.  
 ![screenshot](http://i.imgur.com/GIR3g.png)
 
-Two month, range selection, future dates only, with weekends blacked out:
+Two month, range selection, future dates only, with weekends blacked out:  
 ![screenshot](http://i.imgur.com/JzBc7.png)
 
 ###[View The Demo Page](http://chipersoft.github.com/Kalendae/)
@@ -72,12 +72,12 @@ To ease date handling processes, Kalendae bundles the [moment.js](http://www.mom
 
 The following options are available for configuration.
 
-- `attachTo`:	The element that the calendar div will be appended to.
+- `attachTo`:	The element that the calendar div will be appended to.  
     - In `Kalendae` this defaults to the first argument on the constructor.
     - In `Kalendae.Input` this defaults to the document body.
     - Can be an Element or an element's string ID.
 
-- `format`: The format mask used when parsing date strings.
+- `format`: The format mask used when parsing date strings.  
     - Uses moment.js notation (see http://momentjs.com/docs/#/display/format )
     - If left undefined, will attempt to parse the date automatically.
     - Default is `null`.
@@ -149,7 +149,7 @@ The following settings alter the internal behavior of Kalendae and should only b
 - `dayNumberFormat`: Format string for individual day numbers.
 	- Default is `"D"`
 
-- `dayAttributeFormat`: Format string for the `data-date` attribute set on every span
+- `dayAttributeFormat`: Format string for the `data-date` attribute set on every span 
     - Default is `"YYYY-MM-DD"`
 
 - `parseSplitDelimiter`: RegExp used when splitting multiple dates from a passed string

--- a/src/main.js
+++ b/src/main.js
@@ -183,7 +183,7 @@ var Kalendae = function (targetElement, options) {
 		var clickedDate;
 		if (util.hasClassName(target, classes.nextMonth)) {
 		//NEXT MONTH BUTTON
-			if (!self.disableNext && self.publish('view-changed', self, ['next-month']) !== false) {
+			if (!self.disableNextMonth && self.publish('view-changed', self, ['next-month']) !== false) {
 				self.viewStartDate.add(1, 'months');
 				self.draw();
 			}
@@ -199,7 +199,7 @@ var Kalendae = function (targetElement, options) {
 
 		} else if (util.hasClassName(target, classes.nextYear)) {
 		//NEXT MONTH BUTTON
-			if (!self.disableNext && self.publish('view-changed', self, ['next-year']) !== false) {
+			if (!self.disableNextYear && self.publish('view-changed', self, ['next-year']) !== false) {
 				self.viewStartDate.add(1, 'years');
 				self.draw();
 			}

--- a/src/main.js
+++ b/src/main.js
@@ -532,6 +532,18 @@ Kalendae.prototype = {
 		return false;
 	},
 
+    removeAllSelected : function (draw) {
+        var i = this._sel.length;
+        while (i--) {
+            this.removeSelected(this._sel[i], false);
+            if (i === 0) {
+                if (draw !== false) this.draw();
+                return true;
+            }
+        }
+        return false;
+    },
+
 	draw : function draw() {
 		// return;
 		var month = moment(this.viewStartDate).startOf('month').add(12, 'hours'), //force middle of the day to avoid any weird date shifts

--- a/src/main.js
+++ b/src/main.js
@@ -299,7 +299,7 @@ Kalendae.prototype = {
 		subscribe             :null,            /* object containing events to subscribe to */
 
 		columnHeaderFormat    :'dd',            /* number of characters to show in the column headers */
-		titleMonthFormat      :'MMMM',          /* format mask for month titles. */
+		titleMonthFormat      :'MMMM,',          /* format mask for month titles. */
         titleYearFormat       :'YYYY',          /* format mask for year titles. */
 		dayNumberFormat       :'D',             /* format mask for individual days */
 		dayAttributeFormat    :'YYYY-MM-DD',    /* format mask for the data-date attribute set on every span */

--- a/src/main.js
+++ b/src/main.js
@@ -49,13 +49,13 @@ var Kalendae = function (targetElement, options) {
 		}
 	}
 
-    //set the view month
-    if (!!opts.viewStartDate) {
-        vsd = moment(opts.viewStartDate, opts.format);
-    } else {
-        vsd = moment();
-    }
-    self.viewStartDate = vsd.date(1);
+	//set the view month
+	if (!!opts.viewStartDate) {
+		vsd = moment(opts.viewStartDate, opts.format);
+	} else {
+		vsd = moment();
+	}
+	self.viewStartDate = vsd.date(1);
 
 	//set the end range
 	if (!!opts.endDate) {
@@ -63,12 +63,12 @@ var Kalendae = function (targetElement, options) {
 		self.endDate = ved;
 	}
 
-    //process default selected dates
-    self._sel = [];
-    if (!!opts.selected) {
-        self.setSelected(opts.selected, false);
-        self.viewStartDate = moment(self._sel[0]);
-    }
+	//process default selected dates
+	self._sel = [];
+	if (!!opts.selected) {
+		self.setSelected(opts.selected, false);
+		self.viewStartDate = moment(self._sel[0]);
+	}
 
 	var viewDelta = ({
 		'past'          : opts.months-1,
@@ -127,8 +127,8 @@ var Kalendae = function (targetElement, options) {
 		util.make('a', {'class':classes.nextYear}, $title);               //next button
 		util.make('a', {'class':classes.nextMonth}, $title);              //next button
 		$caption = util.make('div', {'class':classes.caption}, $title);  //title caption
-        util.make('div', {'class':classes.captionMonth}, $caption);          //month text
-        util.make('div', {'class':classes.captionYear}, $caption);           //year text
+        	util.make('div', {'class':classes.captionMonth}, $caption);          //month text
+        	util.make('div', {'class':classes.captionYear}, $caption);           //year text
 
 		//column headers
 		$header = util.make('div', {'class':classes.header + ' ' + (opts.dayHeaderClickable == true ? classes.dayActive : '')}, $cal);
@@ -299,8 +299,8 @@ Kalendae.prototype = {
 		subscribe             :null,            /* object containing events to subscribe to */
 
 		columnHeaderFormat    :'dd',            /* number of characters to show in the column headers */
-		titleMonthFormat      :'MMMM,',          /* format mask for month titles. */
-        titleYearFormat       :'YYYY',          /* format mask for year titles. */
+		titleMonthFormat      :'MMMM,',         /* format mask for month titles. */
+        	titleYearFormat       :'YYYY',          /* format mask for year titles. */
 		dayNumberFormat       :'D',             /* format mask for individual days */
 		dayAttributeFormat    :'YYYY-MM-DD',    /* format mask for the data-date attribute set on every span */
 		parseSplitDelimiter   : /,\s*|\s+-\s+/, /* regex to use for splitting multiple dates from a passed string */
@@ -322,8 +322,8 @@ Kalendae.prototype = {
 		previousYear    :'k-btn-previous-year',
 		nextYear        :'k-btn-next-year',
 		caption         :'k-caption',
-        captionMonth    :'k-caption-month',
-        captionYear     :'k-caption-year',
+        	captionMonth    :'k-caption-month',
+        	captionYear     :'k-caption-year',
 		header          :'k-header',
 		days            :'k-days',
 		week            :'k-week',
@@ -462,7 +462,7 @@ Kalendae.prototype = {
 	addSelected : function (date, draw) {
 		date = moment(date, this.settings.format).hours(12);
 
-		if (date.isAfter(this.endDate, 'day')) return false; // safety for when it wasnt a click
+		if (!!this.endDate && date.isAfter(this.endDate, 'day')) return false; // safety for when it wasnt a click
 
 		if(this.settings.dayOutOfMonthClickable && this.settings.mode !== 'range'){ this.makeSelectedDateVisible(date); }
 
@@ -542,17 +542,17 @@ Kalendae.prototype = {
 		return false;
 	},
 
-    removeAllSelected : function (draw) {
-        var i = this._sel.length;
-        while (i--) {
-            this.removeSelected(this._sel[i], false);
-            if (i === 0) {
-                if (draw !== false) this.draw();
-                return true;
-            }
-        }
-        return false;
-    },
+	removeAllSelected : function (draw) {
+		var i = this._sel.length;
+		while (i--) {
+			this.removeSelected(this._sel[i], false);
+			if (i === 0) {
+				if (draw !== false) this.draw();
+				return true;
+			}
+		}
+		return false;
+	},
 
 	draw : function draw() {
 		// return;
@@ -627,21 +627,21 @@ Kalendae.prototype = {
 				}
 
 				if (day.month() != month.month())
-                    klass.push(classes.dayOutOfMonth);
+        			klass.push(classes.dayOutOfMonth);
 				else klass.push(classes.dayInMonth);
 
-				if (!(this.blackout(day) || this.direction(day) || (this.endDate && day.isAfter(this.endDate, 'day')) || (day.month() != month.month() && opts.dayOutOfMonthClickable === false)) || s>0 )
+				if (!(this.blackout(day) || this.direction(day) || (!!this.endDate && day.isAfter(this.endDate, 'day')) || (day.month() != month.month() && opts.dayOutOfMonthClickable === false)) || s>0 )
 					klass.push(classes.dayActive);
 
                 if (this.blackout(day))
-                    klass.push(classes.dayBlackout);
+                	klass.push(classes.dayBlackout);
 
-                if (day.clone().startOf('day').yearDay() === getTodayYearDate())
-                    klass.push(classes.dayToday);
+				if (day.clone().startOf('day').yearDay() === getTodayYearDate())
+        			klass.push(classes.dayToday);
 
 				dateString = day.format(this.settings.dayAttributeFormat);
 				if (opts.dateClassMap[dateString])
-                    klass.push(opts.dateClassMap[dateString]);
+        			klass.push(opts.dateClassMap[dateString]);
 
 				$span.innerHTML = day.format(opts.dayNumberFormat);
 				$span.className = klass.join(' ');
@@ -662,14 +662,14 @@ Kalendae.prototype = {
 						do {
 							if (firstDay >= startMonth && !this.direction(firstDay)) t++;
 							firstDay.add(7, 'd');
-						} while(firstDay <= endMonth)
+						} while(firstDay <= endMonth);
 
 						if (t == headers[z]) util.addClassName(cal.header.children[z], classes.daySelected);
 						else util.removeClassName(cal.header.children[z], classes.daySelected);
 					}
-				} while(++z < headers.length)
+				} while(++z < headers.length);
 
-    			if (opts.endDate && month.isSame(this.endDate, 'month')) {
+    			if (!!opts.endDate && month.isSame(this.endDate, 'month')) {
     				this.disableNextMonth = true;
     				this.disableNextYear = true;
     				util.addClassName(this.container, classes.disableNextMonth);

--- a/src/main.js
+++ b/src/main.js
@@ -120,7 +120,9 @@ var Kalendae = function (targetElement, options) {
 		util.make('a', {'class':classes.previousMonth}, $title);          //previous button
 		util.make('a', {'class':classes.nextYear}, $title);               //next button
 		util.make('a', {'class':classes.nextMonth}, $title);              //next button
-		$caption = util.make('span', {'class':classes.caption}, $title);  //title caption
+		$caption = util.make('div', {'class':classes.caption}, $title);  //title caption
+        util.make('div', {'class':classes.captionMonth}, $caption);          //month text
+        util.make('div', {'class':classes.captionYear}, $caption);           //year text
 
 		//column headers
 		$header = util.make('div', {'class':classes.header + ' ' + (opts.dayHeaderClickable == true ? classes.dayActive : '')}, $cal);
@@ -290,7 +292,8 @@ Kalendae.prototype = {
 		subscribe             :null,            /* object containing events to subscribe to */
 
 		columnHeaderFormat    :'dd',            /* number of characters to show in the column headers */
-		titleFormat           :'MMMM, YYYY',    /* format mask for month titles. See momentjs.com for rules */
+		titleMonthFormat      :'MMMM',          /* format mask for month titles. */
+        titleYearFormat       :'YYYY',          /* format mask for year titles. */
 		dayNumberFormat       :'D',             /* format mask for individual days */
 		dayAttributeFormat    :'YYYY-MM-DD',    /* format mask for the data-date attribute set on every span */
 		parseSplitDelimiter   : /,\s*|\s+-\s+/, /* regex to use for splitting multiple dates from a passed string */
@@ -312,6 +315,8 @@ Kalendae.prototype = {
 		previousYear    :'k-btn-previous-year',
 		nextYear        :'k-btn-next-year',
 		caption         :'k-caption',
+        captionMonth    :'k-caption-month',
+        captionYear     :'k-caption-year',
 		header          :'k-header',
 		days            :'k-days',
 		week            :'k-week',
@@ -556,8 +561,10 @@ Kalendae.prototype = {
 
 			cal.header.parentNode.setAttribute('data-datestart', month.format(this.settings.dayAttributeFormat));
 
-			cal.caption.innerHTML = month.format(this.settings.titleFormat);
-			j = 0;
+            cal.caption.querySelector('.k-caption-month').innerHTML = month.format(this.settings.titleMonthFormat);
+            cal.caption.querySelector('.k-caption-year').innerHTML = month.format(this.settings.titleYearFormat);
+
+            j = 0;
 			w = 0;
 			t = 0;
 			headers = [];

--- a/src/main.js
+++ b/src/main.js
@@ -327,6 +327,7 @@ Kalendae.prototype = {
 		dayInRange      :'k-range',
 		dayInRangeStart :'k-range-start',
 		dayInRangeEnd   :'k-range-end',
+        dayBlackout     :'k-blackout',
 		dayToday        :'k-today',
 		monthSeparator  :'k-separator',
 		disablePreviousMonth    :'k-disable-previous-month-btn',
@@ -617,15 +618,22 @@ Kalendae.prototype = {
 					}
 				}
 
-				if (day.month() != month.month()) klass.push(classes.dayOutOfMonth);
+				if (day.month() != month.month())
+                    klass.push(classes.dayOutOfMonth);
 				else klass.push(classes.dayInMonth);
 
-				if (!(this.blackout(day) || this.direction(day) || (day.month() != month.month() && opts.dayOutOfMonthClickable === false)) || s>0) klass.push(classes.dayActive);
+				if (!(this.blackout(day) || this.direction(day) || (day.month() != month.month() && opts.dayOutOfMonthClickable === false)) || s>0 )
+                    klass.push(classes.dayActive);
 
-				if (day.clone().startOf('day').yearDay() === getTodayYearDate()) klass.push(classes.dayToday);
+                if (this.blackout(day))
+                    klass.push(classes.dayBlackout);
+
+				if (day.clone().startOf('day').yearDay() === getTodayYearDate())
+                    klass.push(classes.dayToday);
 
 				dateString = day.format(this.settings.dayAttributeFormat);
-				if (opts.dateClassMap[dateString]) klass.push(opts.dateClassMap[dateString]);
+				if (opts.dateClassMap[dateString])
+                    klass.push(opts.dateClassMap[dateString]);
 
 				$span.innerHTML = day.format(opts.dayNumberFormat);
 				$span.className = klass.join(' ');

--- a/src/main.js
+++ b/src/main.js
@@ -631,12 +631,12 @@ Kalendae.prototype = {
 				else klass.push(classes.dayInMonth);
 
 				if (!(this.blackout(day) || this.direction(day) || day.isAfter(this.endDate, 'day') || (day.month() != month.month() && opts.dayOutOfMonthClickable === false)) || s>0 )
-					klass.push(classes.dayActive);
+                    klass.push(classes.dayActive);
 
                 if (this.blackout(day))
                     klass.push(classes.dayBlackout);
 
-				if (day.clone().startOf('day').yearDay() === getTodayYearDate())
+                if (day.clone().startOf('day').yearDay() === getTodayYearDate())
                     klass.push(classes.dayToday);
 
 				dateString = day.format(this.settings.dayAttributeFormat);

--- a/src/main.js
+++ b/src/main.js
@@ -630,7 +630,7 @@ Kalendae.prototype = {
                     klass.push(classes.dayOutOfMonth);
 				else klass.push(classes.dayInMonth);
 
-				if (!(this.blackout(day) || this.direction(day) || day.isAfter(this.endDate, 'day') || (day.month() != month.month() && opts.dayOutOfMonthClickable === false)) || s>0 )
+				if (!(this.blackout(day) || this.direction(day) || (this.endDate && day.isAfter(this.endDate, 'day')) || (day.month() != month.month() && opts.dayOutOfMonthClickable === false)) || s>0 )
 					klass.push(classes.dayActive);
 
                 if (this.blackout(day))

--- a/src/main.js
+++ b/src/main.js
@@ -631,7 +631,7 @@ Kalendae.prototype = {
 				else klass.push(classes.dayInMonth);
 
 				if (!(this.blackout(day) || this.direction(day) || day.isAfter(this.endDate, 'day') || (day.month() != month.month() && opts.dayOutOfMonthClickable === false)) || s>0 )
-                    klass.push(classes.dayActive);
+					klass.push(classes.dayActive);
 
                 if (this.blackout(day))
                     klass.push(classes.dayBlackout);

--- a/src/main.js
+++ b/src/main.js
@@ -696,6 +696,7 @@ Kalendae.prototype = {
 				}
 			}
 		}
+        this.publish('draw-end', this);
 	}
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -580,13 +580,12 @@ Kalendae.prototype = {
 			//if the first day of the month is less than our week start, back up a week
 
 			cal = this.calendars[i];
-
 			cal.header.parentNode.setAttribute('data-datestart', month.format(this.settings.dayAttributeFormat));
 
             cal.caption.querySelector('.k-caption-month').innerHTML = month.format(this.settings.titleMonthFormat);
             cal.caption.querySelector('.k-caption-year').innerHTML = month.format(this.settings.titleYearFormat);
 
-            j = 0;
+			j = 0;
 			w = 0;
 			t = 0;
 			headers = [];


### PR DESCRIPTION
First off, this has as lot of changes (though mostly very simple) in one request. I did not test extensively. But I have been working in Chrome & IE9. So far, so good. 

Feel free to take bits and pieces of this.

I made sure to break it up into commits for each feature. So you can see each one on its own. (Aside from the last commit, which was a bit of an afterthought).

In more detail:

* fixed variables - f17ab6b - for some reason both variables for disable next were `disableNext` sans the declaration. So I added Month and Year respectively
* Month Caption adjustments - d973408 - I changed the title span to a div, and placed the month and year in their own divs so they can be styled on their own if needed. (e.g. http://i.imgur.com/y0yK34I.png )
* removeAllSelected() - 8ac3047 - I needed this in my own code, and I figured I'd be doing it more than once, so I just wrote a method and added it in. 
* 'draw-end' event - 120b579 - I needed to do more jQuery styling after a draw had finished and I had no way of knowing without relying on a combination of "view-changed" and "change", and even then there were still gaps. 
* 'k-blackout' class - 35f21cc - because sometimes you want to style blacked out dates differently than inactive dates
* endDate option - 2955464 - I had a situation where I need to limit not just the direction the calendar starts in, but also where it ends. And so I added this to control that. Following all the patterns set out by previous day selection options.

* The last 3 commits are just updating the readme, fixing the css for the title, and fixing a bug #2697 that I realized due to moment

thanks for making such a great, agnostic, datepicker! I'm really enjoying using it. And modifying it. 