### PR TITLE
Close calendar pop when selecting date

### DIFF
--- a/build/kalendae.standalone.js
+++ b/build/kalendae.standalone.js
@@ -1043,6 +1043,10 @@ Kalendae.Input = function (targetElement, options) {
 		}
 		$input.value = self.getSelected();
 		util.fireEvent($input, 'change');
+		if (opts.closeOnSelection && opts.mode === 'single') {
+			$input.blur();
+			self.hide();
+		}
 	});
 
 };

--- a/index.html
+++ b/index.html
@@ -189,6 +189,16 @@
 			months:2
 		});
 	</script>
+	<hr>
+	
+	Click this input element (Auto closes after selection): <input type="text" value="2/16/2012" id="input2">
+	<script type="text/javascript" charset="utf-8">
+		var k4 = new Kalendae.Input('input2', {
+			months:1,
+			closeOnSelection: true
+		});
+	</script>
+
 
 	<hr>
 	This calendar is auto-created.

--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,8 @@ The following options are available for configuration.
     - In "multiple" mode, strings may contain multiple dates separated by commas. *ex: 2/3/2012, 3/15/2012, 4/2/2012*
     - In "range" mode, strings may contain two dates separated by a hyphen. *ex: 2/3/2012 - 3/15/2012*
 
+- `closeOnSelection`: Setting to `true` and in `Kalendae.Input` the calendar popup will automatically close when a date is picked.
+
 - `months`:	The total number of months to display side by side on the calendar.
     - Default is `1`.
 

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,9 @@ The following options are available for configuration.
     - In "multiple" mode, strings may contain multiple dates separated by commas. *ex: 2/3/2012, 3/15/2012, 4/2/2012*
     - In "range" mode, strings may contain two dates separated by a hyphen. *ex: 2/3/2012 - 3/15/2012*
 
-- `closeOnSelection`: Setting to `true` and in `Kalendae.Input` the calendar popup will automatically close when a date is picked.
+- `closeOnSelection`: Close the calendar popup when a date is selected.
+    - Only works in `Kalendae.Input` and in `single` mode.
+    - Default is `false`.
 
 - `months`:	The total number of months to display side by side on the calendar.
     - Default is `1`.

--- a/src/input.js
+++ b/src/input.js
@@ -95,6 +95,9 @@ Kalendae.Input = function (targetElement, options) {
 		}
 		$input.value = self.getSelected();
 		util.fireEvent($input, 'change');
+		if (opts.closeOnSelection) {
+			self.hide();
+		}
 	});
 
 };

--- a/src/input.js
+++ b/src/input.js
@@ -95,7 +95,7 @@ Kalendae.Input = function (targetElement, options) {
 		}
 		$input.value = self.getSelected();
 		util.fireEvent($input, 'change');
-		if (opts.closeOnSelection) {
+		if (opts.closeOnSelection && opts.mode === 'single') {
 			self.hide();
 		}
 	});

--- a/src/input.js
+++ b/src/input.js
@@ -96,6 +96,7 @@ Kalendae.Input = function (targetElement, options) {
 		$input.value = self.getSelected();
 		util.fireEvent($input, 'change');
 		if (opts.closeOnSelection && opts.mode === 'single') {
+			$input.blur();
 			self.hide();
 		}
 	});


### PR DESCRIPTION
#185   Adds a new option to the options object named "closeOnSelection" If set to true the calendar will automatically hide when a date is selected.

It currently works in `single` mode, however it could also be changed to support range (but not multiple as we don't know how many dates a user wants to pick to close it automatically)

