### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-##Contributing to Kalendae
+## Contributing to Kalendae
 
 1. Please submit all pull requests to the `dev` branch from your own named branch (not your master).
 2. Please only include the changes within the `src/` directory, do not include new builds.

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-#Kalendae - A framework agnostic javascript date picker
+# Kalendae - A framework agnostic javascript date picker
 
 Kalendae is an attempt to do something that nobody has yet been able to do: make a date picker that doesn't suck.  Kalendae provides the following features:
 
@@ -13,7 +13,7 @@ Kalendae is an attempt to do something that nobody has yet been able to do: make
 9. Output selected dates in a variety of formats
 10. Leverages [moment.js](http://www.momentjs.com) for smart and easy date parsing.
 
-##Screenshots
+## Screenshots
 
 Default calendar, no options defined.  
 ![screenshot](http://i.imgur.com/Ig52z.png)
@@ -24,10 +24,10 @@ Two month calendar attached to an input element.
 Two month, range selection, future dates only, with weekends blacked out:  
 ![screenshot](http://i.imgur.com/JzBc7.png)
 
-###[View The Demo Page](http://chipersoft.github.com/Kalendae/)
+### [View The Demo Page](http://chipersoft.github.com/Kalendae/)
 
 
-##Usage
+## Usage
 
 Copy the contents of the `build/` folder into wherever your website scripts are kept.  Include the JS and CSS files in the head of your document like so:
 ```html
@@ -56,11 +56,11 @@ You can also setup Kalendae manually via JavaScript code. This should be done ei
 
 See the included index.html file for usage examples.
 
-###jQuery
+### jQuery
 
 Kalendae does not require jQuery, but does provide a jQuery plugin when jQuery is available.  jQuery users may create a Kalendae widget or popup by calling `$(selector).kalendae(options)`.  If `selector` is an HTML input element, an instance of Kalendae.Input is created, otherwise the instance will be Kalendae.  This instance is stored via jQuery's data method and can be accessed via `$(selector).data('kalendae')`.
 
-##moment.js
+## moment.js
 
 To ease date handling processes, Kalendae bundles the [moment.js](http://www.momentjs.com) date handling library.  This bundled library has been altered to prevent it from being added to the global context, but is still available if you wish to use it in your own code.  Add the following directly after the `<script>` tag to make moment available for your application.
 ```html
@@ -68,7 +68,7 @@ To ease date handling processes, Kalendae bundles the [moment.js](http://www.mom
     window.moment = Kalendae.moment;
 </script>
 ```
-##Options
+## Options
 
 The following options are available for configuration.
 
@@ -129,7 +129,7 @@ The following options are available for configuration.
 - `side`: Chooses the side on which to display the picker. Default is `bottom`.
 
 
-###Advanced Behavior Options
+### Advanced Behavior Options
 
 The following settings alter the internal behavior of Kalendae and should only be changed by advanced users.
 
@@ -154,13 +154,13 @@ The following settings alter the internal behavior of Kalendae and should only b
 - `multipleDelimiter`: String used to delimit dates when outputting in multiple mode
     - Default is `', '`
 
-###Example Blackout Functions
+### Example Blackout Functions
 
 - Blackout weekends: `function (date) {return [1,0,0,0,0,0,1][Kalendae.moment(date).day()];}`
 - Blackout every other day: `function (date) {return Kalendae.moment(date).date() % 2;}`
 - Blackout every other week `function (date) {return Kalendae.moment(date).format('w') % 2;}`
 
-##Member Functions
+## Member Functions
 
 The following functions are available on the instantiated `Kalendae` and `Kalendae.Input` objects.
 
@@ -182,7 +182,7 @@ The following functions are available on the instantiated `Kalendae` and `Kalend
 
 - `draw()`: Forces a redraw of the calendar contents.
 
-##Member Properties
+## Member Properties
 
 The following properties are exposed on the instantiated `Kalendae` and `Kalendae.Input` objects.
 
@@ -192,7 +192,7 @@ The following properties are exposed on the instantiated `Kalendae` and `Kalenda
 
 - `calendars`: The individual month divs (see the `months` option).
 
-##Kalendae Events
+## Kalendae Events
 
 Kalendae uses a publish/subscribe event system.  To receive events from a Kalendae instance you can call the `subscribe()` function on the Kalendae instance, passing the event name and a callback function.  Example:
 ```js
@@ -226,12 +226,12 @@ Additionally, Kalendae.Input provides the following events:
 - `hide` - Fires when the calendar hides due to the input blurring
 
 
-##Skinning Kalendae
+## Skinning Kalendae
 
 Coming Soon.
 
 
-##Building Kalendae
+## Building Kalendae
 
 The Kalendae source code is assembled from multiple individual files.  A standard GNU makefile is included to compile the files together into the finished product.
 
@@ -240,13 +240,13 @@ To build Kalendae, navigate to the directory containing this readme file in the 
 To create a minified version, run `make minified`.  If the minified file is blank, run `make minified-test` to see what errors Google Closure Compiler is throwing.
 
 
-##Contributing to Kalendae
+## Contributing to Kalendae
 
 1. Please submit all pull requests to the `dev` branch from your own named branch.
 2. Please only include the changes within the `src/` directory, do not include new builds.
 3. New code should match the existing code style, with hard tabs for indentation, spaces for alignment, and [BSD/KNF style bracketing](http://en.wikipedia.org/wiki/Indent_style#BSD_KNF_style).
 4. Please be aware that I have family and work obligations and may take some time to respond to your Pull Request.
 
-##License
+## License
 
 Kalendae is released under an MIT license and is freely distributable.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
